### PR TITLE
【InReview】途中終了機能の追加

### DIFF
--- a/MyGame.xcodeproj/project.pbxproj
+++ b/MyGame.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 		840C97EB1C87C61B0069128F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0640;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "トライアローズ開発";
 				TargetAttributes = {
 					840C97F21C87C61B0069128F = {
@@ -296,6 +296,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -361,6 +362,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MyGame/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "TA.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -371,6 +373,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MyGame/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "TA.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -389,6 +392,7 @@
 				);
 				INFOPLIST_FILE = MyGameTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "TA.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MyGame.app/MyGame";
 			};
@@ -404,6 +408,7 @@
 				);
 				INFOPLIST_FILE = MyGameTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "TA.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MyGame.app/MyGame";
 			};

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -144,10 +144,10 @@
 - (BOOL)judgeRowDraw
 {
     // 全ての横行に◯×の両方が含まれていれば、引き分け
-    BOOL isFirst = NO;
-    BOOL isSecond = NO;
-    
     for (NSMutableArray *rows in self.masViews) {
+        BOOL isFirst = NO;
+        BOOL isSecond = NO;
+
         for (MasuView *masView in rows) {
             // tempTitleに文字を一度のみ格納する。
             if (!masView.title || masView.title.length == 0) {
@@ -175,10 +175,10 @@
 - (BOOL)judgeColmnDraw
 {
     // 全ての縦列に◯×の両方が含まれていれば、引き分け
-    __block BOOL isFirst = NO;
-    __block BOOL isSecond = NO;
-    
     for (NSUInteger colmn = 0; colmn < self.masNumber; colmn++) {
+        __block BOOL isFirst = NO;
+        __block BOOL isSecond = NO;
+
         [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
             MasuView *masView = rows[colmn];
 

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -106,13 +106,14 @@
     return YES;
 }
 
+#pragma mark - Draw
 /*
  引き分け判定
  @return NOなら途中。YESなら引き分け。
 */
 - (BOOL)judgeDraw
 {
-    NSInteger count;
+    NSInteger count = 0;
     
     // 横
     if ([self judgeRowDraw]){
@@ -143,31 +144,28 @@
 - (BOOL)judgeRowDraw
 {
     // 全ての横行に◯×の両方が含まれていれば、引き分け
-    
-    NSString *tempTitle = nil;
-    NSInteger count = 0;
+    BOOL isFirst = NO;
+    BOOL isSecond = NO;
     
     for (NSMutableArray *rows in self.masViews) {
         for (MasuView *masView in rows) {
             // tempTitleに文字を一度のみ格納する。
             if (!masView.title || masView.title.length == 0) {
                 continue;
-            }else if (tempTitle == nil){
-                tempTitle = masView.title;
-                continue;
+            }else if ([masView.title isEqualToString:self.firstTitle]) {
+                isFirst = YES;
+            }else if ([masView.title isEqualToString:self.secondTitle]) {
+                isSecond = YES;
             }
-            
-            if (![masView.title isEqualToString:tempTitle]) {
-                count++;
-            }
+        }
+        
+        // 1つの行に◯もしくは×が含まれていなければ、継続する。
+        if (isFirst == NO || isSecond == NO) {
+            return NO;
         }
     }
     
-    if (self.masNumber == count) {
-        return YES;
-    }
-    
-    return NO;
+    return YES;
 }
 
 /*
@@ -176,9 +174,9 @@
  */
 - (BOOL)judgeColmnDraw
 {
-    // 全ての横行に◯×の両方が含まれていれば、引き分け
-    __block NSString *tempTitle = nil;
-    __block NSInteger count = 0;
+    // 全ての縦列に◯×の両方が含まれていれば、引き分け
+    __block BOOL isFirst = NO;
+    __block BOOL isSecond = NO;
     
     for (NSUInteger colmn = 0; colmn < self.masNumber; colmn++) {
         [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
@@ -187,22 +185,19 @@
             // tempTitleに文字を一度のみ格納する。
             if (!masView.title || masView.title.length == 0) {
                 return;
-            }else if (tempTitle == nil){
-                tempTitle = masView.title;
-                return;
-            }
-            
-            if (![masView.title isEqualToString:tempTitle]) {
-                count++;
+            }else if ([masView.title isEqualToString:self.firstTitle]){
+                isFirst = YES;
+            }else if ([masView.title isEqualToString:self.secondTitle]){
+                isSecond = YES;
             }
         }];
+        
+        if (isFirst == NO || isSecond == NO) {
+            return NO;
+        }
     }
     
-    if (self.masNumber == count) {
-        return YES;
-    }
-    
-    return NO;
+    return YES;
 }
 
 /*
@@ -211,8 +206,8 @@
  */
 - (BOOL)judgeSlantingDraw
 {
-    __block NSString *tempTitle = nil;
-    __block NSInteger count = 0;
+    __block BOOL isFirst = NO;
+    __block BOOL isSecond = NO;
     __block NSUInteger colmn = 0;
     
     // 1回目
@@ -222,21 +217,22 @@
         // tempTitleに文字を一度のみ格納する。
         if (!masView.title || masView.title.length == 0) {
             return;
-        }else if (tempTitle == nil){
-            tempTitle = masView.title;
-            return;
-        }
-        
-        if (![masView.title isEqualToString:tempTitle]) {
-            count++;
+        }else if ([masView.title isEqualToString:self.firstTitle]){
+            isFirst = YES;
+        }else if ([masView.title isEqualToString:self.secondTitle]){
+            isSecond = YES;
         }
         
         colmn++;
     }];
     
-    // リセット
-    tempTitle = nil;
+    if (isFirst == NO || isSecond == NO) {
+        return NO;
+    }
     
+    isFirst = NO;
+    isSecond = NO;
+
     // 2回目
     // 対角線なので2回だけ実行
     colmn = self.masNumber -1;
@@ -246,25 +242,23 @@
         // tempTitleに文字を一度のみ格納する。
         if (!masView.title || masView.title.length == 0) {
             return;
-        }else if (tempTitle == nil){
-            tempTitle = masView.title;
-            return;
-        }
-        
-        if (![masView.title isEqualToString:tempTitle]) {
-            count++;
+        }else if ([masView.title isEqualToString:self.firstTitle]){
+            isFirst = YES;
+        }else if ([masView.title isEqualToString:self.secondTitle]){
+            isSecond = YES;
         }
         
         colmn--;
     }];
     
-    if (count == 2) {
-        return YES;
+    if (isFirst == NO || isSecond == NO) {
+        return NO;
     }
     
-    return NO;
+    return YES;
 }
 
+#pragma mark - Winner
 /*
  勝者判定
  @return 0なら途中。1なら先攻が勝ち。2なら後攻が勝ち。

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -150,9 +150,7 @@
 
         for (MasuView *masView in rows) {
             // tempTitleに文字を一度のみ格納する。
-            if (!masView.title || masView.title.length == 0) {
-                continue;
-            }else if ([masView.title isEqualToString:self.firstTitle]) {
+            if ([masView.title isEqualToString:self.firstTitle]) {
                 isFirst = YES;
             }else if ([masView.title isEqualToString:self.secondTitle]) {
                 isSecond = YES;
@@ -183,9 +181,7 @@
             MasuView *masView = rows[colmn];
 
             // tempTitleに文字を一度のみ格納する。
-            if (!masView.title || masView.title.length == 0) {
-                return;
-            }else if ([masView.title isEqualToString:self.firstTitle]){
+            if ([masView.title isEqualToString:self.firstTitle]){
                 isFirst = YES;
             }else if ([masView.title isEqualToString:self.secondTitle]){
                 isSecond = YES;
@@ -215,9 +211,7 @@
     [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
         MasuView *masView = rows[colmn];
         // tempTitleに文字を一度のみ格納する。
-        if (!masView.title || masView.title.length == 0) {
-            return;
-        }else if ([masView.title isEqualToString:self.firstTitle]){
+        if ([masView.title isEqualToString:self.firstTitle]){
             isFirst = YES;
         }else if ([masView.title isEqualToString:self.secondTitle]){
             isSecond = YES;
@@ -227,6 +221,7 @@
     }];
     
     if (isFirst == NO || isSecond == NO) {
+        NSLog(@"斜めNo1回目");
         return NO;
     }
     
@@ -240,9 +235,7 @@
     [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
         MasuView *masView = rows[colmn];
         // tempTitleに文字を一度のみ格納する。
-        if (!masView.title || masView.title.length == 0) {
-            return;
-        }else if ([masView.title isEqualToString:self.firstTitle]){
+        if ([masView.title isEqualToString:self.firstTitle]){
             isFirst = YES;
         }else if ([masView.title isEqualToString:self.secondTitle]){
             isSecond = YES;
@@ -252,9 +245,11 @@
     }];
     
     if (isFirst == NO || isSecond == NO) {
+        NSLog(@"斜めNo2回目");
         return NO;
     }
     
+    NSLog(@"斜めOK");
     return YES;
 }
 

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -90,7 +90,6 @@
  */
 - (BOOL)isFinishedGame
 {
-    // FIXME: ここ直してます
     if ([self judgeDraw]) {
         return YES;
     }

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -90,6 +90,11 @@
  */
 - (BOOL)isFinishedGame
 {
+    // FIXME: ここ直してます
+    if ([self judgeDraw]) {
+        return YES;
+    }
+    
     for (NSMutableArray *rows in self.masViews) {
         for (MasuView *masView in rows) {
             if (!masView.title || masView.title.length == 0) {
@@ -99,6 +104,165 @@
     }
     
     return YES;
+}
+
+/*
+ 引き分け判定
+ @return NOなら途中。YESなら引き分け。
+*/
+- (BOOL)judgeDraw
+{
+    NSInteger count;
+    
+    // 横
+    if ([self judgeRowDraw]){
+        count++;
+    }
+    
+    // 縦
+    if ([self judgeColmnDraw]) {
+        count++;
+    }
+    
+    // 斜め
+    if ([self judgeSlantingDraw]) {
+        count++;
+    }
+    
+    if (count == 3) {
+        return YES;
+    }else{
+        return NO;
+    }
+}
+
+/*
+ 行(横方向)の引き分け判定
+ @return NOなら途中。YESなら引き分け。
+ */
+- (BOOL)judgeRowDraw
+{
+    // 全ての横行に◯×の両方が含まれていれば、引き分け
+    
+    NSString *tempTitle = nil;
+    NSInteger count = 0;
+    
+    for (NSMutableArray *rows in self.masViews) {
+        for (MasuView *masView in rows) {
+            // tempTitleに文字を一度のみ格納する。
+            if (!masView.title || masView.title.length == 0) {
+                continue;
+            }else if (tempTitle == nil){
+                tempTitle = masView.title;
+                continue;
+            }
+            
+            if (![masView.title isEqualToString:tempTitle]) {
+                count++;
+            }
+        }
+    }
+    
+    if (self.masNumber == count) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+/*
+ 列(縦方向)の引き分け判定
+ @return NOなら途中。YESなら引き分け。
+ */
+- (BOOL)judgeColmnDraw
+{
+    // 全ての横行に◯×の両方が含まれていれば、引き分け
+    __block NSString *tempTitle = nil;
+    __block NSInteger count = 0;
+    
+    for (NSUInteger colmn = 0; colmn < self.masNumber; colmn++) {
+        [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
+            MasuView *masView = rows[colmn];
+
+            // tempTitleに文字を一度のみ格納する。
+            if (!masView.title || masView.title.length == 0) {
+                return;
+            }else if (tempTitle == nil){
+                tempTitle = masView.title;
+                return;
+            }
+            
+            if (![masView.title isEqualToString:tempTitle]) {
+                count++;
+            }
+        }];
+    }
+    
+    if (self.masNumber == count) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+/*
+ 斜めの引き分け判定
+ @return NOなら途中。YESなら引き分け。
+ */
+- (BOOL)judgeSlantingDraw
+{
+    __block NSString *tempTitle = nil;
+    __block NSInteger count = 0;
+    __block NSUInteger colmn = 0;
+    
+    // 1回目
+    // 対角線なので2回だけ実行
+    [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
+        MasuView *masView = rows[colmn];
+        // tempTitleに文字を一度のみ格納する。
+        if (!masView.title || masView.title.length == 0) {
+            return;
+        }else if (tempTitle == nil){
+            tempTitle = masView.title;
+            return;
+        }
+        
+        if (![masView.title isEqualToString:tempTitle]) {
+            count++;
+        }
+        
+        colmn++;
+    }];
+    
+    // リセット
+    tempTitle = nil;
+    
+    // 2回目
+    // 対角線なので2回だけ実行
+    colmn = self.masNumber -1;
+    
+    [self.masViews enumerateObjectsUsingBlock:^(NSMutableArray *rows, NSUInteger idx, BOOL *stop) {
+        MasuView *masView = rows[colmn];
+        // tempTitleに文字を一度のみ格納する。
+        if (!masView.title || masView.title.length == 0) {
+            return;
+        }else if (tempTitle == nil){
+            tempTitle = masView.title;
+            return;
+        }
+        
+        if (![masView.title isEqualToString:tempTitle]) {
+            count++;
+        }
+        
+        colmn--;
+    }];
+    
+    if (count == 2) {
+        return YES;
+    }
+    
+    return NO;
 }
 
 /*

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -220,7 +220,6 @@
     }];
     
     if (isFirst == NO || isSecond == NO) {
-        NSLog(@"斜めNo1回目");
         return NO;
     }
     
@@ -244,11 +243,9 @@
     }];
     
     if (isFirst == NO || isSecond == NO) {
-        NSLog(@"斜めNo2回目");
         return NO;
     }
     
-    NSLog(@"斜めOK");
     return YES;
 }
 
@@ -272,7 +269,6 @@
     }
     
     // ななめ
-    
     NSInteger slantingWinner = [self judgeSlantingWinner];
     if (slantingWinner != 0) {
         return slantingWinner;

--- a/MyGame/Info.plist
+++ b/MyGame/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>TA.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/MyGameTests/Info.plist
+++ b/MyGameTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>TA.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
# 途中終了機能

ゲームの途中であっても確実に引き分けになるパターンがある。
確実に引き分けになると分かった時点で「引き分け」時と同様の処理を実行する。
# 概要

表題の通り
# バグ原因
## 直接原因

ゲームの途中でゲームを終了させる判定処理を入れていなかったため。
## 根本原因

未実装であったため。
# 対応詳細

ゲームの途中でゲームを終了させる判定処理を追加。
