### PR TITLE
【In Review】 引き分け時に、「後攻」の勝利としてカウントされてしまう問題のバグ対応

### DIFF
--- a/MyGame/BoardView.h
+++ b/MyGame/BoardView.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "RecordData.h"
 
 @protocol BoardViewDelegate;
 
@@ -44,7 +45,7 @@
  勝敗がついたときに呼ばれる
  @param winFirst 先攻が勝者の場合YES.後攻が勝者の場合NO.
  */
-- (void)boardView:(BoardView *)boardView finishGameWinFirst:(BOOL)winFirst;
+- (void)boardView:(BoardView *)boardView finishGameWinFirst:(ResultType)resultType;
 
  @optional
 /**

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -363,7 +363,7 @@
     
     // リセット処理を親が実装(GameViewController)
     if ([self.delegate respondsToSelector:@selector(boardView:finishGameWinFirst:)]) {
-        [self.delegate boardView:self finishGameWinFirst:(win==1)?YES:NO];
+        [self.delegate boardView:self finishGameWinFirst:win];
     }
 }
 

--- a/MyGame/GameViewController.m
+++ b/MyGame/GameViewController.m
@@ -144,10 +144,10 @@
  勝敗がついたときに呼ばれる
  @param winFirst 先攻が勝者の場合YES.後攻が勝者の場合NO.
  */
-- (void)boardView:(BoardView *)boardView finishGameWinFirst:(BOOL)winFirst
+- (void)boardView:(BoardView *)boardView finishGameWinFirst:(ResultType)resultType
 {
     // 勝敗記録
-    [RecordData saveResult:(winFirst)?ResultTypeFirst:ResultTypeSecond];
+    [RecordData saveResult:resultType];
 }
 
 /*

--- a/MyGame/RecordData.h
+++ b/MyGame/RecordData.h
@@ -9,7 +9,8 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, ResultType) {
-    ResultTypeFirst = 1,
+    ResultTypeDraw   = 0,
+    ResultTypeFirst  = 1,
     ResultTypeSecond = 2,
 };
 

--- a/MyGame/RecordData.m
+++ b/MyGame/RecordData.m
@@ -9,8 +9,9 @@
 #import "RecordData.h"
 
 static NSString * const keyUserdefaultResult = @"result";
-static NSString * const keyFirstWin = @"first";
+static NSString * const keyFirstWin  = @"first";
 static NSString * const keySecondWin = @"second";
+static NSString * const keyDraw      = @"draw";
 
 @implementation RecordData
 
@@ -27,7 +28,20 @@ static NSString * const keySecondWin = @"second";
         r = [record mutableCopy];
     }
     
-    NSString *winKey = (result == ResultTypeFirst)?keyFirstWin:keySecondWin;
+    NSString *winKey;
+    
+    switch (result) {
+        case ResultTypeFirst:
+            winKey = keyFirstWin;
+            break;
+        case ResultTypeSecond:
+            winKey = keySecondWin;
+            break;
+        case ResultTypeDraw:
+            winKey = keyDraw;
+            break;
+    }
+    
     NSNumber *numWinCount = r[winKey];
     if (!numWinCount) {
         numWinCount = @(0);

--- a/MyGame/RootViewController.m
+++ b/MyGame/RootViewController.m
@@ -147,7 +147,7 @@
         self.resultLabel = rLabel;
     }
     
-    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%d勝 後攻:%d勝",firstWin,secondWin];
+    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%ld勝 後攻:%ld勝",firstWin,secondWin];
 }
 
 #pragma mark - Event


### PR DESCRIPTION
# 概要

表題の通り
# バグ原因
## 直接原因

勝敗を記録する際、勝敗結果の値が「1」なら「先攻の勝ち」、それ以外なら「後攻の勝ち」として記録されていたことが原因。
つまり、引き分けを表す値が渡された時に、「後攻の勝ち」と同じ処理がされていた。
## 根本原因

コーディングミス。
「先攻勝ち」「後攻勝ち」以外の値が渡された場合の処理が抜けている。
# 対応詳細

勝敗結果を表すENUMに「引き分け」を追加。
それに応じてメソッドを修正。
