### PR TITLE
【In Review】 タイトル画面に「引き分け」表記を追加

### DIFF
--- a/MyGame/BoardView.h
+++ b/MyGame/BoardView.h
@@ -43,7 +43,7 @@
  @required
 /**
  勝敗がついたときに呼ばれる
- @param winFirst 先攻が勝者の場合YES.後攻が勝者の場合NO.
+ @param resultType 勝敗を表すENUMの値
  */
 - (void)boardView:(BoardView *)boardView finishGameWinFirst:(ResultType)resultType;
 

--- a/MyGame/BoardView.h
+++ b/MyGame/BoardView.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "RecordData.h"
 
 @protocol BoardViewDelegate;
 
@@ -44,7 +45,7 @@
  勝敗がついたときに呼ばれる
  @param winFirst 先攻が勝者の場合YES.後攻が勝者の場合NO.
  */
-- (void)boardView:(BoardView *)boardView finishGameWinFirst:(BOOL)winFirst;
+- (void)boardView:(BoardView *)boardView finishGameWinFirst:(ResultType)resultType;
 
  @optional
 /**

--- a/MyGame/BoardView.m
+++ b/MyGame/BoardView.m
@@ -363,7 +363,7 @@
     
     // リセット処理を親が実装(GameViewController)
     if ([self.delegate respondsToSelector:@selector(boardView:finishGameWinFirst:)]) {
-        [self.delegate boardView:self finishGameWinFirst:(win==1)?YES:NO];
+        [self.delegate boardView:self finishGameWinFirst:win];
     }
 }
 

--- a/MyGame/GameViewController.m
+++ b/MyGame/GameViewController.m
@@ -144,10 +144,10 @@
  勝敗がついたときに呼ばれる
  @param winFirst 先攻が勝者の場合YES.後攻が勝者の場合NO.
  */
-- (void)boardView:(BoardView *)boardView finishGameWinFirst:(BOOL)winFirst
+- (void)boardView:(BoardView *)boardView finishGameWinFirst:(ResultType)resultType
 {
     // 勝敗記録
-    [RecordData saveResult:(winFirst)?ResultTypeFirst:ResultTypeSecond];
+    [RecordData saveResult:resultType];
 }
 
 /*

--- a/MyGame/RecordData.h
+++ b/MyGame/RecordData.h
@@ -9,7 +9,8 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, ResultType) {
-    ResultTypeFirst = 1,
+    ResultTypeDraw   = 0,
+    ResultTypeFirst  = 1,
     ResultTypeSecond = 2,
 };
 

--- a/MyGame/RecordData.m
+++ b/MyGame/RecordData.m
@@ -9,8 +9,9 @@
 #import "RecordData.h"
 
 static NSString * const keyUserdefaultResult = @"result";
-static NSString * const keyFirstWin = @"first";
+static NSString * const keyFirstWin  = @"first";
 static NSString * const keySecondWin = @"second";
+static NSString * const keyDraw      = @"draw";
 
 @implementation RecordData
 
@@ -27,7 +28,20 @@ static NSString * const keySecondWin = @"second";
         r = [record mutableCopy];
     }
     
-    NSString *winKey = (result == ResultTypeFirst)?keyFirstWin:keySecondWin;
+    NSString *winKey;
+    
+    switch (result) {
+        case ResultTypeFirst:
+            winKey = keyFirstWin;
+            break;
+        case ResultTypeSecond:
+            winKey = keySecondWin;
+            break;
+        case ResultTypeDraw:
+            winKey = keyDraw;
+            break;
+    }
+    
     NSNumber *numWinCount = r[winKey];
     if (!numWinCount) {
         numWinCount = @(0);

--- a/MyGame/RecordData.m
+++ b/MyGame/RecordData.m
@@ -69,7 +69,18 @@ static NSString * const keyDraw      = @"draw";
         r = [record mutableCopy];
     }
     
-    NSString *winKey = (result == ResultTypeFirst)?keyFirstWin:keySecondWin;
+    NSString *winKey;
+    switch (result) {
+        case ResultTypeFirst:
+            winKey = keyFirstWin;
+            break;
+        case ResultTypeSecond:
+            winKey = keySecondWin;
+            break;
+        case ResultTypeDraw:
+            winKey = keyDraw;
+            break;
+    }
     
     NSNumber *numWinCount = r[winKey];
     if (!numWinCount) {

--- a/MyGame/RootViewController.m
+++ b/MyGame/RootViewController.m
@@ -143,6 +143,8 @@
         rLabel.textColor = [UIColor whiteColor];
         rLabel.font = [UIFont boldSystemFontOfSize:16];
         rLabel.textAlignment = NSTextAlignmentCenter;
+        rLabel.minimumScaleFactor = 10.0f; //最小フォントサイズを指定
+        rLabel.adjustsFontSizeToFitWidth = YES;
         
         [self.view addSubview:rLabel];
         self.resultLabel = rLabel;

--- a/MyGame/RootViewController.m
+++ b/MyGame/RootViewController.m
@@ -147,7 +147,7 @@
         self.resultLabel = rLabel;
     }
     
-    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%d勝 後攻:%d勝",firstWin,secondWin];
+    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%ld勝 後攻:%ld勝",firstWin,secondWin];
 }
 
 #pragma mark - Event

--- a/MyGame/RootViewController.m
+++ b/MyGame/RootViewController.m
@@ -133,7 +133,8 @@
 {
     NSInteger firstWin = [RecordData loadResult:ResultTypeFirst];
     NSInteger secondWin = [RecordData loadResult:ResultTypeSecond];
-    
+    NSInteger draw = [RecordData loadResult:ResultTypeDraw];
+
     if (!self.resultLabel) {
         
         CGRect rc = [[UIScreen mainScreen] applicationFrame];
@@ -147,7 +148,7 @@
         self.resultLabel = rLabel;
     }
     
-    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%ld勝 後攻:%ld勝",firstWin,secondWin];
+    self.resultLabel.text = [NSString stringWithFormat:@"先攻:%ld勝 後攻:%ld勝 引き分け:%ld",firstWin,secondWin,draw];
 }
 
 #pragma mark - Event


### PR DESCRIPTION
# 概要

タイトル画面に「先攻」「後攻」各々の勝利数しかカウントされていないので、「引き分け」の表記を追加する。
# 修正の詳細

・UserDefaultからの読み込みメソッドに、「引き分け」時の処理を追加。
・タイトル画面のLabel生成処理の中に、「引き分け」結果の読み込みと表示を追加
## 修正後のスクリーンショット

![mbg_01](https://cloud.githubusercontent.com/assets/12635163/13559500/22bbab16-e458-11e5-8e85-8577461fd34b.png)

![mbg_02](https://cloud.githubusercontent.com/assets/12635163/13559505/2797ab26-e458-11e5-93b1-12bbf1da5e48.png)
